### PR TITLE
Add guided budget wizard (Phase 1 MVP)

### DIFF
--- a/components/Budget/Tour.vue
+++ b/components/Budget/Tour.vue
@@ -1,35 +1,55 @@
 <template>
-  <main class="p-2 bg-light min-h-screen flex items-center">
+  <main class="p-2 bg-light min-h-screen">
     <portal to="title">
       <transition appear name="slide-down">
         <div class="text-lg">Welcome to MoneyDo</div>
       </transition>
     </portal>
+
     <transition appear name="zoom-in-out">
       <div
-        class="w-full text-center text-primary rounded bg-white p-4 shadow my-2"
+        v-if="!showWizard"
+        class="w-full text-center text-primary rounded bg-white p-4 shadow my-2 mx-auto max-w-screen-sm"
       >
         <TIcon class="inline-block" name="piggy" />
         <div class="text-3xl mt-2 leading-tight">
-          Take € under control
+          Take your money under control
         </div>
-        <div>by creating your first budget</div>
-        <TButton type="primary" class="inline-block mt-4" to="/app/budgets/-"
-          >Create Budget</TButton
+        <div class="mt-2 text-gray-600">
+          Plan your budget using the Kakeibo method
+        </div>
+        <TButton
+          type="primary"
+          class="inline-block mt-4"
+          @click="showWizard = true"
         >
+          Create Budget
+        </TButton>
+        <div class="mt-3">
+          <TButton type="link" to="/app/budgets/-">
+            Quick setup (advanced)
+          </TButton>
+        </div>
       </div>
     </transition>
+
+    <BudgetWizard v-if="showWizard" />
   </main>
 </template>
 
 <script>
 import TIcon from '~/components/TIcon'
 import TButton from '~/components/TButton'
+import BudgetWizard from '~/components/Budget/Wizard'
 
 export default {
   components: {
     TIcon,
-    TButton
-  }
+    TButton,
+    BudgetWizard
+  },
+  data: () => ({
+    showWizard: false
+  })
 }
 </script>

--- a/components/Budget/Wizard.vue
+++ b/components/Budget/Wizard.vue
@@ -1,0 +1,256 @@
+<template>
+  <div class="max-w-screen-sm mx-auto">
+    <div class="p-4 bg-gray-200 flex justify-between items-center rounded-t">
+      <h1 class="text-gray-700 text-lg font-bold">Budget Planner</h1>
+      <span v-if="!saving" class="text-gray-500"
+        >{{ step }} / {{ totalSteps }}</span
+      >
+    </div>
+
+    <div class="p-4 bg-white rounded-b shadow">
+      <WizardIntro v-if="step === 1" />
+
+      <WizardIncome
+        v-if="step === 2"
+        :income.sync="income"
+        :month.sync="month"
+      />
+
+      <WizardExpenses
+        v-if="step === 3"
+        :expenses.sync="expenses"
+        :income="income"
+      />
+
+      <WizardSavings
+        v-if="step === 4"
+        :savings.sync="savings"
+        :income="income"
+        :expenses="expenses"
+      />
+
+      <WizardBudget
+        v-if="step === 5"
+        :planned.sync="planned"
+        :income="income"
+        :expenses="expenses"
+        :savings="savings"
+      />
+
+      <WizardSummary
+        v-if="step === 6"
+        :month="month"
+        :income="income"
+        :expenses="expenses"
+        :savings="savings"
+        :planned="planned"
+        :total-days="totalDays"
+      />
+
+      <div class="flex justify-between mt-6">
+        <div>
+          <TButton v-if="step > 1" type="simple" @click="prevStep">
+            Back
+          </TButton>
+        </div>
+        <div>
+          <TButton v-if="step < totalSteps" type="primary" @click="nextStep">
+            Next
+          </TButton>
+          <TButton
+            v-if="step === totalSteps"
+            type="primary"
+            :disabled="saving"
+            @click="saveBudget"
+          >
+            {{ saving ? 'Saving...' : 'Save Budget' }}
+          </TButton>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { getDaysInMonth, getYear, getMonth, formatISO9075 } from 'date-fns'
+import useAuth from '~/use/auth'
+import useDoc from '~/use/doc'
+import TButton from '~/components/TButton'
+import WizardIntro from '~/components/Budget/WizardIntro'
+import WizardIncome from '~/components/Budget/WizardIncome'
+import WizardExpenses from '~/components/Budget/WizardExpenses'
+import WizardSavings from '~/components/Budget/WizardSavings'
+import WizardBudget from '~/components/Budget/WizardBudget'
+import WizardSummary from '~/components/Budget/WizardSummary'
+
+export default {
+  components: {
+    TButton,
+    WizardIntro,
+    WizardIncome,
+    WizardExpenses,
+    WizardSavings,
+    WizardBudget,
+    WizardSummary
+  },
+  data() {
+    const now = new Date()
+    const currentMonth = getMonth(now) + 1
+
+    return {
+      step: 1,
+      totalSteps: 6,
+      now,
+      month: currentMonth,
+      income: '',
+      expenses: '',
+      savings: '',
+      planned: {
+        needs: 0,
+        wants: 0,
+        culture: 0,
+        extra: 0
+      },
+      saving: false
+    }
+  },
+  setup() {
+    const { updateAccount } = useAuth()
+    const { create } = useDoc('budgets')
+
+    return {
+      updateAccount,
+      createBudget: create
+    }
+  },
+  computed: {
+    monthName() {
+      const names = [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December'
+      ]
+      return names[parseInt(this.month) - 1] || ''
+    },
+    startDate() {
+      const m = parseInt(this.month) - 1
+      const year = getYear(this.now)
+      return new Date(year, m, 1)
+    },
+    endDate() {
+      const m = parseInt(this.month) - 1
+      const year = getYear(this.now)
+      const endDay = getDaysInMonth(this.startDate)
+      return new Date(year, m, endDay)
+    },
+    totalDays() {
+      return getDaysInMonth(this.startDate)
+    }
+  },
+  watch: {
+    income(val) {
+      if (this.step <= 3) {
+        this.recalculate()
+      }
+    },
+    expenses() {
+      if (this.step <= 4) {
+        this.recalculate()
+      }
+    },
+    savings() {
+      if (this.step <= 5) {
+        this.recalculateEnvelopes()
+      }
+    }
+  },
+  methods: {
+    recalculate() {
+      const inc = parseInt(this.income) || 0
+      this.savings = Math.round(inc * 0.2)
+      this.recalculateEnvelopes()
+    },
+    recalculateEnvelopes() {
+      const inc = parseInt(this.income) || 0
+      const exp = parseInt(this.expenses) || 0
+      const sav = parseInt(this.savings) || 0
+      const leftover = inc - exp - sav
+
+      if (leftover <= 0) {
+        this.planned = { needs: 0, wants: 0, culture: 0, extra: 0 }
+        return
+      }
+
+      // 50/30/20 logic adapted from existing _id.vue calculate()
+      let needs = Math.round(inc * 0.5) - exp
+      if (needs <= 0) {
+        needs = leftover
+      }
+      if (needs > leftover) {
+        needs = leftover
+      }
+
+      const wants = leftover - needs
+      this.planned = {
+        needs,
+        wants: Math.round(wants * 0.8),
+        culture: Math.round(wants * 0.1),
+        extra: Math.round(wants * 0.1)
+      }
+    },
+    prevStep() {
+      if (this.step > 1) {
+        this.step--
+      }
+    },
+    nextStep() {
+      if (this.step < this.totalSteps) {
+        this.step++
+      }
+    },
+    async saveBudget() {
+      this.saving = true
+
+      try {
+        const budgetData = {
+          name: this.monthName,
+          month: parseInt(this.month),
+          start: formatISO9075(this.startDate, { representation: 'date' }),
+          end: formatISO9075(this.endDate, { representation: 'date' }),
+          income: parseInt(this.income) || 0,
+          expenses: parseInt(this.expenses) || 0,
+          savings: parseInt(this.savings) || 0,
+          planned: {
+            needs: parseInt(this.planned.needs) || 0,
+            wants: parseInt(this.planned.wants) || 0,
+            culture: parseInt(this.planned.culture) || 0,
+            extra: parseInt(this.planned.extra) || 0
+          }
+        }
+
+        const doc = await this.createBudget(budgetData)
+
+        await this.updateAccount({
+          budgetId: doc.id
+        })
+
+        this.$emit('complete', doc.id)
+        this.$router.push('/app/')
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to save budget:', e)
+        this.saving = false
+      }
+    }
+  }
+}
+</script>

--- a/components/Budget/WizardBudget.vue
+++ b/components/Budget/WizardBudget.vue
@@ -1,0 +1,136 @@
+<template>
+  <div>
+    <h2 class="text-gray-700 text-xl font-bold mb-2">
+      Envelope Allocation
+    </h2>
+    <p class="mb-4 text-gray-500">
+      Distribute your remaining budget across four envelopes. We've
+      pre-calculated based on the 50/30/20 rule.
+    </p>
+
+    <div class="p-3 bg-gray-100 rounded mb-4">
+      <div class="flex justify-between text-gray-700">
+        <span>Income</span>
+        <span class="font-mono">{{ income }}</span>
+      </div>
+      <div class="flex justify-between text-gray-700 mt-1">
+        <span>Fixed Expenses</span>
+        <span class="font-mono">-{{ expenses }}</span>
+      </div>
+      <div class="flex justify-between text-gray-700 mt-1">
+        <span>Savings</span>
+        <span class="font-mono">-{{ savings }}</span>
+      </div>
+      <div class="flex justify-between text-gray-700 mt-1 border-t pt-1">
+        <span class="font-bold">To allocate</span>
+        <span class="font-mono font-bold">{{ leftover }}</span>
+      </div>
+    </div>
+
+    <div v-for="envelope in envelopesList" :key="envelope.name" class="mb-4">
+      <TField
+        :value="localPlanned[envelope.name]"
+        :label="envelope.label"
+        type="tel"
+        class="rounded border p-2"
+        :description="envelope.description"
+        @input="updateEnvelope(envelope.name, $event)"
+      />
+    </div>
+
+    <div
+      class="mt-4 p-3 rounded"
+      :class="balance === 0 ? 'bg-green-100' : 'bg-orange-100'"
+    >
+      <div class="flex justify-between">
+        <span
+          class="font-bold"
+          :class="balance === 0 ? 'text-green-700' : 'text-orange-700'"
+        >
+          Balance
+        </span>
+        <span
+          class="font-mono font-bold"
+          :class="balance === 0 ? 'text-green-700' : 'text-orange-700'"
+        >
+          {{ balance }}
+        </span>
+      </div>
+    </div>
+
+    <TTip v-if="balance !== 0" type="warning" class="mt-4">
+      Adjust your envelopes so the balance is 0. You have
+      {{
+        balance > 0
+          ? balance + ' left to allocate'
+          : Math.abs(balance) + ' over-allocated'
+      }}.
+    </TTip>
+
+    <TTip v-else type="success" class="mt-4">
+      Your budget is balanced. Every euro is accounted for.
+    </TTip>
+  </div>
+</template>
+
+<script>
+import TField from '~/components/TField'
+import TTip from '~/components/TTip'
+import useEnvelopes from '~/use/envelopes'
+
+export default {
+  components: {
+    TField,
+    TTip
+  },
+  props: {
+    planned: {
+      type: Object,
+      default: () => ({})
+    },
+    income: {
+      type: [String, Number],
+      default: 0
+    },
+    expenses: {
+      type: [String, Number],
+      default: 0
+    },
+    savings: {
+      type: [String, Number],
+      default: 0
+    }
+  },
+  setup() {
+    const { envelopes } = useEnvelopes()
+    return { envelopesList: envelopes }
+  },
+  computed: {
+    localPlanned() {
+      return this.planned || {}
+    },
+    leftover() {
+      return (
+        parseInt(this.income || 0) -
+        parseInt(this.expenses || 0) -
+        parseInt(this.savings || 0)
+      )
+    },
+    envelopesTotal() {
+      return Object.values(this.localPlanned).reduce(
+        (sum, val) => sum + parseInt(val || 0),
+        0
+      )
+    },
+    balance() {
+      return this.leftover - this.envelopesTotal
+    }
+  },
+  methods: {
+    updateEnvelope(name, value) {
+      const updated = { ...this.localPlanned, [name]: value }
+      this.$emit('update:planned', updated)
+    }
+  }
+}
+</script>

--- a/components/Budget/WizardExpenses.vue
+++ b/components/Budget/WizardExpenses.vue
@@ -1,0 +1,84 @@
+<template>
+  <div>
+    <h2 class="text-gray-700 text-xl font-bold mb-2">
+      Fixed Expenses
+    </h2>
+    <p class="mb-4 text-gray-500">
+      Enter the total of your regular monthly expenses: rent, mortgage, utility
+      bills, insurance, phone, transport, gym, subscriptions, loans, etc.
+    </p>
+
+    <TField
+      v-model="localExpenses"
+      label="Fixed Expenses"
+      type="tel"
+      class="rounded border p-2"
+      description="The total of everything you pay each month that doesn't change."
+    />
+
+    <div v-if="income > 0" class="mt-4 p-3 bg-gray-100 rounded">
+      <div class="flex justify-between text-gray-700">
+        <span>Income</span>
+        <span class="font-mono">{{ income }}</span>
+      </div>
+      <div class="flex justify-between text-gray-700 mt-1">
+        <span>Fixed Expenses</span>
+        <span class="font-mono text-red-600">-{{ localExpenses || 0 }}</span>
+      </div>
+      <div class="flex justify-between text-gray-700 mt-1 border-t pt-1">
+        <span class="font-bold">Remaining</span>
+        <span
+          class="font-mono font-bold"
+          :class="remaining < 0 ? 'text-red-600' : 'text-green-600'"
+        >
+          {{ remaining }}
+        </span>
+      </div>
+    </div>
+
+    <TTip v-if="remaining < 0" type="warning" class="mt-4">
+      Your expenses exceed your income. Consider reducing expenses or adjusting
+      your income estimate.
+    </TTip>
+
+    <TTip v-else class="mt-4">
+      Use previous bills for anything you need to estimate. It's better to plan
+      for higher costs than lower.
+    </TTip>
+  </div>
+</template>
+
+<script>
+import TField from '~/components/TField'
+import TTip from '~/components/TTip'
+
+export default {
+  components: {
+    TField,
+    TTip
+  },
+  props: {
+    expenses: {
+      type: [String, Number],
+      default: ''
+    },
+    income: {
+      type: [String, Number],
+      default: 0
+    }
+  },
+  computed: {
+    localExpenses: {
+      get() {
+        return this.expenses
+      },
+      set(val) {
+        this.$emit('update:expenses', val)
+      }
+    },
+    remaining() {
+      return parseInt(this.income || 0) - parseInt(this.localExpenses || 0)
+    }
+  }
+}
+</script>

--- a/components/Budget/WizardIncome.vue
+++ b/components/Budget/WizardIncome.vue
@@ -1,0 +1,85 @@
+<template>
+  <div>
+    <h2 class="text-gray-700 text-xl font-bold mb-2">
+      Monthly Income
+    </h2>
+    <p class="mb-4 text-gray-500">
+      Enter your total monthly net income (after tax). If your income varies,
+      make an educated guess.
+    </p>
+
+    <TSelect v-model="localMonth" label="Month" :options="months" />
+
+    <TField
+      v-model="localIncome"
+      label="Income (after tax)"
+      type="tel"
+      class="mt-4 rounded border p-2"
+      description="Your total monthly income after taxes and deductions."
+    />
+
+    <TTip class="mt-4">
+      Round up to whole numbers to keep calculations simple.
+    </TTip>
+  </div>
+</template>
+
+<script>
+import TField from '~/components/TField'
+import TSelect from '~/components/TSelect'
+import TTip from '~/components/TTip'
+
+export default {
+  components: {
+    TField,
+    TSelect,
+    TTip
+  },
+  props: {
+    income: {
+      type: [String, Number],
+      default: ''
+    },
+    month: {
+      type: [String, Number],
+      default: ''
+    }
+  },
+  data() {
+    return {
+      months: [
+        { value: 1, label: 'January' },
+        { value: 2, label: 'February' },
+        { value: 3, label: 'March' },
+        { value: 4, label: 'April' },
+        { value: 5, label: 'May' },
+        { value: 6, label: 'June' },
+        { value: 7, label: 'July' },
+        { value: 8, label: 'August' },
+        { value: 9, label: 'September' },
+        { value: 10, label: 'October' },
+        { value: 11, label: 'November' },
+        { value: 12, label: 'December' }
+      ]
+    }
+  },
+  computed: {
+    localIncome: {
+      get() {
+        return this.income
+      },
+      set(val) {
+        this.$emit('update:income', val)
+      }
+    },
+    localMonth: {
+      get() {
+        return this.month
+      },
+      set(val) {
+        this.$emit('update:month', val)
+      }
+    }
+  }
+}
+</script>

--- a/components/Budget/WizardIntro.vue
+++ b/components/Budget/WizardIntro.vue
@@ -1,0 +1,86 @@
+<template>
+  <div>
+    <div class="font-serif text-gray-700 leading-loose">
+      <p>Hello,</p>
+      <p class="mt-2">
+        Let's plan your personal budget together. We'll use the
+        <strong>Kakeibo</strong> method combined with the
+        <strong>50/30/20</strong> rule to help you spend mindfully.
+      </p>
+    </div>
+
+    <dl class="mt-6">
+      <dt
+        class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow mb-3 cursor-pointer select-none"
+        @click="faq1 = !faq1"
+      >
+        What is Kakeibo?
+      </dt>
+      <dd v-if="faq1" class="px-2 text-gray-600 mb-3">
+        <p class="mb-4">
+          Kakeibo was invented in 1904 by Japan's first female journalist,
+          Motoko Hani.
+        </p>
+        <p>
+          The Japanese tradition of using a kakeibo, which translates to
+          "household finance ledger," offers an easy solution to mindless
+          spending habits. This budgeting system combines tracking purchases
+          with the habit of mindfulness in order to reign in unnecessary
+          spending and help you achieve savings goals.
+          <a
+            class="underline text-primary"
+            href="https://www.credit.com/personal-finance/kakeibo/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Learn more</a
+          >.
+        </p>
+      </dd>
+
+      <dt
+        class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow mb-3 cursor-pointer select-none"
+        @click="faq2 = !faq2"
+      >
+        What is 50/30/20?
+      </dt>
+      <dd v-if="faq2" class="px-2 text-gray-600 mb-3">
+        <p class="mb-4">
+          Elizabeth Warren popularized the 50/30/20 budget rule in her book "All
+          Your Worth: The Ultimate Lifetime Money Plan".
+        </p>
+        <p>
+          The 50-30-20 rule puts 50% of your income toward necessities, like
+          housing and bills. Twenty percent should then go toward financial
+          goals, like paying off debt or saving for retirement. Finally, 30% of
+          your income can be allocated to wants, like dining or entertainment.
+          <a
+            class="underline text-primary"
+            href="https://www.thebalance.com/the-50-30-20-rule-of-thumb-453922"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Learn more</a
+          >.
+        </p>
+      </dd>
+    </dl>
+
+    <TTip class="mt-4">
+      In the next steps, we'll help you set up your income, expenses, savings,
+      and spending envelopes with sensible defaults.
+    </TTip>
+  </div>
+</template>
+
+<script>
+import TTip from '~/components/TTip'
+
+export default {
+  components: {
+    TTip
+  },
+  data: () => ({
+    faq1: false,
+    faq2: false
+  })
+}
+</script>

--- a/components/Budget/WizardSavings.vue
+++ b/components/Budget/WizardSavings.vue
@@ -1,0 +1,116 @@
+<template>
+  <div>
+    <h2 class="text-gray-700 text-xl font-bold mb-2">
+      Savings Target
+    </h2>
+    <p class="mb-4 text-gray-500">
+      Decide how much you want to save. We recommend saving 20% of your income.
+    </p>
+
+    <div class="p-3 bg-gray-100 rounded mb-4">
+      <div class="flex justify-between text-gray-700">
+        <span>Income</span>
+        <span class="font-mono text-green-600">+{{ income }}</span>
+      </div>
+      <div class="flex justify-between text-gray-700 mt-1">
+        <span>Fixed Expenses</span>
+        <span class="font-mono text-red-600">-{{ expenses }}</span>
+      </div>
+      <div class="flex justify-between text-gray-700 mt-1">
+        <span>Savings ({{ savingsPercent }}%)</span>
+        <span class="font-mono text-red-600">-{{ localSavings || 0 }}</span>
+      </div>
+      <div class="flex justify-between text-gray-700 mt-1 border-t pt-1">
+        <span class="font-bold">Left to spend</span>
+        <span
+          class="font-mono font-bold"
+          :class="leftToSpend < 0 ? 'text-red-600' : 'text-green-600'"
+        >
+          {{ leftToSpend }}
+        </span>
+      </div>
+    </div>
+
+    <div class="pt-8 pb-4 px-2">
+      <vue-slider v-model="savingsPercent" tooltip="always" :min="0" :max="100">
+        <template v-slot:tooltip="{ value }">
+          <div class="p-1 rounded text-sm text-white bg-primary">
+            {{ value }}%
+          </div>
+        </template>
+      </vue-slider>
+    </div>
+
+    <TField
+      v-model="localSavings"
+      label="Savings Amount"
+      type="tel"
+      class="mt-2 rounded border p-2"
+    />
+
+    <TTip v-if="savingsPercent < 20" type="warning" class="mt-4">
+      Try to save at least 20% of your income. Right now it's
+      {{ savingsPercent }}%.
+    </TTip>
+
+    <TTip v-else type="success" class="mt-4">
+      You're saving {{ savingsPercent }}% of your income.
+    </TTip>
+  </div>
+</template>
+
+<script>
+import VueSlider from 'vue-slider-component'
+import TField from '~/components/TField'
+import TTip from '~/components/TTip'
+
+export default {
+  components: {
+    VueSlider,
+    TField,
+    TTip
+  },
+  props: {
+    savings: {
+      type: [String, Number],
+      default: ''
+    },
+    income: {
+      type: [String, Number],
+      default: 0
+    },
+    expenses: {
+      type: [String, Number],
+      default: 0
+    }
+  },
+  computed: {
+    localSavings: {
+      get() {
+        return this.savings
+      },
+      set(val) {
+        this.$emit('update:savings', val)
+      }
+    },
+    savingsPercent: {
+      get() {
+        const inc = parseInt(this.income) || 0
+        if (inc <= 0) return 0
+        return Math.round((parseInt(this.localSavings || 0) / inc) * 100)
+      },
+      set(val) {
+        const inc = parseInt(this.income) || 0
+        this.localSavings = Math.round((val / 100) * inc)
+      }
+    },
+    leftToSpend() {
+      return (
+        parseInt(this.income || 0) -
+        parseInt(this.expenses || 0) -
+        parseInt(this.localSavings || 0)
+      )
+    }
+  }
+}
+</script>

--- a/components/Budget/WizardSummary.vue
+++ b/components/Budget/WizardSummary.vue
@@ -1,0 +1,173 @@
+<template>
+  <div>
+    <h2 class="text-gray-700 text-xl font-bold mb-2">
+      Your Budget Summary
+    </h2>
+    <p class="mb-4 text-gray-500">
+      Review your budget plan. When everything looks good, hit Save to start
+      tracking.
+    </p>
+
+    <div class="bg-white rounded shadow p-4">
+      <div class="flex justify-between py-2 border-b">
+        <span class="text-gray-600">Month</span>
+        <span class="font-bold text-gray-700">{{ monthName }}</span>
+      </div>
+      <div class="flex justify-between py-2 border-b">
+        <span class="text-gray-600">Income</span>
+        <span class="font-mono text-green-600 font-bold">{{ income }}</span>
+      </div>
+      <div class="flex justify-between py-2 border-b">
+        <span class="text-gray-600">Fixed Expenses</span>
+        <span class="font-mono text-red-600">-{{ expenses }}</span>
+      </div>
+      <div class="flex justify-between py-2 border-b">
+        <span class="text-gray-600">Savings ({{ savingsPercent }}%)</span>
+        <span class="font-mono text-red-600">-{{ savings }}</span>
+      </div>
+      <div class="flex justify-between py-2 border-b font-bold">
+        <span class="text-gray-700">Available to Spend</span>
+        <span class="font-mono text-gray-700">{{ leftover }}</span>
+      </div>
+
+      <h3 class="mt-4 mb-2 font-bold text-gray-700">Envelopes</h3>
+      <div
+        v-for="envelope in envelopesList"
+        :key="envelope.name"
+        class="flex justify-between py-1"
+      >
+        <span class="text-gray-600">{{ envelope.label }}</span>
+        <span class="font-mono text-gray-700">
+          {{ planned[envelope.name] || 0 }}
+          <span class="text-xs text-gray-500">
+            (~{{ dailyAmount(envelope.name) }}/day)
+          </span>
+        </span>
+      </div>
+
+      <div
+        class="flex justify-between py-2 mt-2 border-t font-bold"
+        :class="balance === 0 ? 'text-green-700' : 'text-orange-700'"
+      >
+        <span>Balance</span>
+        <span class="font-mono">{{ balance }}</span>
+      </div>
+    </div>
+
+    <div v-if="hasWarnings" class="mt-4">
+      <div
+        v-if="savingsPercent < 20"
+        class="mb-2 bg-orange-100 border border-orange-400 text-orange-700 px-4 py-3 rounded"
+      >
+        <strong class="font-bold">Savings below 20%.</strong>
+        Consider increasing your savings to build a safety net.
+      </div>
+      <div
+        v-if="balance !== 0"
+        class="mb-2 bg-orange-100 border border-orange-400 text-orange-700 px-4 py-3 rounded"
+      >
+        <strong class="font-bold">Budget not balanced.</strong>
+        Go back and adjust your envelopes so the balance is 0.
+      </div>
+    </div>
+
+    <TTip v-if="!hasWarnings" type="success" class="mt-4">
+      Your budget looks great! Save it to start tracking your daily spending.
+    </TTip>
+  </div>
+</template>
+
+<script>
+import TTip from '~/components/TTip'
+import useEnvelopes from '~/use/envelopes'
+
+export default {
+  components: {
+    TTip
+  },
+  props: {
+    month: {
+      type: [String, Number],
+      default: ''
+    },
+    income: {
+      type: [String, Number],
+      default: 0
+    },
+    expenses: {
+      type: [String, Number],
+      default: 0
+    },
+    savings: {
+      type: [String, Number],
+      default: 0
+    },
+    planned: {
+      type: Object,
+      default: () => ({})
+    },
+    totalDays: {
+      type: Number,
+      default: 30
+    }
+  },
+  setup() {
+    const { envelopes } = useEnvelopes()
+    return { envelopesList: envelopes }
+  },
+  computed: {
+    monthNames() {
+      return [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December'
+      ]
+    },
+    monthName() {
+      const idx = parseInt(this.month) - 1
+      return this.monthNames[idx] || ''
+    },
+    leftover() {
+      return (
+        parseInt(this.income || 0) -
+        parseInt(this.expenses || 0) -
+        parseInt(this.savings || 0)
+      )
+    },
+    savingsPercent() {
+      const inc = parseInt(this.income) || 0
+      if (inc <= 0) return 0
+      return Math.round((parseInt(this.savings || 0) / inc) * 100)
+    },
+    envelopesTotal() {
+      return Object.values(this.planned).reduce(
+        (sum, val) => sum + parseInt(val || 0),
+        0
+      )
+    },
+    balance() {
+      return this.leftover - this.envelopesTotal
+    },
+    hasWarnings() {
+      return this.savingsPercent < 20 || this.balance !== 0
+    }
+  },
+  methods: {
+    dailyAmount(envelope) {
+      const days = this.totalDays || 30
+      return (
+        Math.round((parseInt(this.planned[envelope] || 0) / days) * 100) / 100
+      )
+    }
+  }
+}
+</script>

--- a/components/TTip.vue
+++ b/components/TTip.vue
@@ -1,0 +1,42 @@
+<template>
+  <div
+    :class="
+      `mt-4 bg-${finalColor}-100 border border-${finalColor}-400 text-${finalColor}-700 px-4 py-3 rounded relative`
+    "
+    role="alert"
+  >
+    <strong v-if="type === 'tip'" class="font-bold">Tip: </strong>
+    <strong v-if="type === 'warning'" class="font-bold">Warning: </strong>
+    <span class="block sm:inline">
+      <slot />
+    </span>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    type: {
+      type: String,
+      default: 'tip'
+    },
+    color: {
+      type: String,
+      default: ''
+    }
+  },
+  data: () => ({
+    colors: {
+      tip: 'blue',
+      warning: 'orange',
+      success: 'green',
+      error: 'red'
+    }
+  }),
+  computed: {
+    finalColor() {
+      return this.color ? this.color : this.colors[this.type] || 'blue'
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## Summary

- **Extracted** the 9-step budget planner wizard from `razbakov/moneydo-budget` into 8 focused components in the main app
- **Replaced** the bare "Create Budget" button (`BudgetTour`) with an inline 6-step guided wizard that teaches Kakeibo/50-30-20 budgeting
- **Wired** wizard completion to Firestore via existing `use/doc.js` — creates standard budget documents with no schema changes
- **Preserved** the existing quick-setup form at `/app/budgets/-` as an "advanced" option

## New Components

| Component | Purpose |
|-----------|---------|
| `Budget/Wizard.vue` | Step orchestrator — manages state, back/next navigation, save to Firestore |
| `Budget/WizardIntro.vue` | Kakeibo + 50/30/20 education with expandable FAQ dropdowns |
| `Budget/WizardIncome.vue` | Month selector + income entry |
| `Budget/WizardExpenses.vue` | Fixed expenses entry with running total breakdown |
| `Budget/WizardSavings.vue` | Savings slider with 20% default + warnings |
| `Budget/WizardBudget.vue` | Auto-calculated 4-envelope allocation (needs/wants/culture/extra) |
| `Budget/WizardSummary.vue` | Review all values with daily amounts, save button |
| `TTip.vue` | Reusable contextual tip/warning/success alerts (ported from budget planner) |

## Updated Components

- `Budget/Tour.vue` — shows wizard inline on "Create Budget" click, keeps quick-setup link

## Design Decisions

- **No schema extension** — Phase 1 uses single `income`/`expenses`/`savings` numbers, matching existing budget documents. `incomeItems`/`expenseItems` deferred to Phase 2.
- **50/30/20 auto-calculation** — envelope allocation is pre-calculated using the same logic as the existing `_id.vue` form, then user can adjust manually.
- **`.sync` modifier** — used for two-way prop binding between Wizard and step components (Vue 2 pattern, matches codebase style).
- **No new dependencies** — uses existing `vue-slider-component`, `date-fns`, TButton/TField/TSelect/TIcon.

## What's NOT included (Phase 2+)

- Motivation/questionnaire steps
- Itemized income/expense entry
- Savings goal tracking
- PDF export
- i18n translations

## Test Plan

- [ ] New user sees welcome screen → clicks "Create Budget" → wizard appears
- [ ] Step 1: Kakeibo/50-30-20 FAQs expand/collapse correctly
- [ ] Step 2: Month defaults to current month, income field accepts numbers
- [ ] Step 3: Expenses field shows remaining calculation
- [ ] Step 4: Savings slider defaults to 20%, warning appears below 20%
- [ ] Step 5: Envelopes auto-calculated, balance shows 0 when correct
- [ ] Step 6: Summary shows all values with daily amounts
- [ ] Save creates budget in Firestore, sets `budgetId` on account, redirects to dashboard
- [ ] "Quick setup (advanced)" link still goes to `/app/budgets/-`
- [ ] Existing budget editing at `/app/budgets/:id` unchanged
- [ ] Back/Next navigation works correctly across all steps

## References

- Integration plan: `docs/domains/product/operations/backlog/budget-planner-integration.md`
- Source: `razbakov/moneydo-budget` (812-line monolithic `pages/index.vue`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive multi-step budget wizard that guides users through entering monthly income, fixed expenses, savings targets, and allocating funds across budget envelopes.
  * Introduced budget planning guides with FAQ sections explaining budgeting methodologies.
  * Added contextual tips and warnings throughout the budget setup flow for user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->